### PR TITLE
Add QR template generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# QR Template Generator
+
+This repository contains a simple script for generating QR codes from a URL and placing them on a custom template image.
+
+## Requirements
+
+- Python 3.8+
+- [`qrcode`](https://pypi.org/project/qrcode/) with Pillow support
+- [`Pillow`](https://pypi.org/project/Pillow/)
+
+Install dependencies with:
+
+```bash
+pip install qrcode[pil] Pillow
+```
+
+## Usage
+
+```
+python qr_template_generator.py URL -t TEMPLATE_PATH [options]
+```
+
+Options:
+
+- `-o`, `--output`: Name of the generated image file (default: `output.png`).
+- `--x`: X coordinate of the QR code's top-left corner on the template (default: `0`).
+- `--y`: Y coordinate of the QR code's top-left corner on the template (default: `0`).
+- `--size`: Size of the generated QR code in pixels (default: `300`).
+
+The template image should be any standard image format (PNG, JPEG, etc.). The script will place the generated QR code onto the template at the specified coordinates and save the result as the output image. You can then print the resulting file with any image viewer.
+
+## Example
+
+```
+python qr_template_generator.py "https://example.com" -t my_template.png --x 50 --y 100 -o qr_output.png
+```
+
+This will create `qr_output.png` with a QR code for `https://example.com` pasted onto `my_template.png` at position `(50, 100)`.
+

--- a/qr_template_generator.py
+++ b/qr_template_generator.py
@@ -1,0 +1,44 @@
+import argparse
+from pathlib import Path
+
+try:
+    import qrcode
+    from PIL import Image
+except ImportError as e:
+    raise SystemExit("Required packages not found. Please install 'qrcode[pil]' and 'Pillow'.")
+
+
+def generate_qr(url: str, qr_size: int = 300) -> Image.Image:
+    """Generate a QR code image from a URL."""
+    qr = qrcode.QRCode(error_correction=qrcode.constants.ERROR_CORRECT_M)
+    qr.add_data(url)
+    qr.make(fit=True)
+    img = qr.make_image(fill_color="black", back_color="white").convert("RGB")
+    return img.resize((qr_size, qr_size), Image.LANCZOS)
+
+
+def apply_template(template_path: Path, qr_img: Image.Image, x: int, y: int) -> Image.Image:
+    """Paste the QR code onto the template at the given coordinates."""
+    template = Image.open(template_path).convert("RGB")
+    template.paste(qr_img, (x, y))
+    return template
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate a QR code on a template image")
+    parser.add_argument("url", help="URL to encode in the QR code")
+    parser.add_argument("-t", "--template", required=True, help="Path to background template image")
+    parser.add_argument("-o", "--output", default="output.png", help="Output image filename")
+    parser.add_argument("--x", type=int, default=0, help="X coordinate for QR code placement")
+    parser.add_argument("--y", type=int, default=0, help="Y coordinate for QR code placement")
+    parser.add_argument("--size", type=int, default=300, help="Width/height of generated QR code in pixels")
+    args = parser.parse_args()
+
+    qr_img = generate_qr(args.url, args.size)
+    result = apply_template(Path(args.template), qr_img, args.x, args.y)
+    result.save(args.output)
+    print(f"Saved QR template to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a script `qr_template_generator.py` that builds a QR code from a URL and places it on a template image
- document requirements and usage in `README.md`

## Testing
- `python3 -m py_compile qr_template_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_684415d32ac0832194833e165f88fa87